### PR TITLE
Refactor plugin configuration (for lolcommits v0.10.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ try the following:
 
 ```
 loltext:
-  enabled: true
+  :enabled: true
   :message:
     :color: white
     :font: "/Users/matt/Library/Fonts/Raleway-Light.ttf"

--- a/lib/lolcommits/loltext/version.rb
+++ b/lib/lolcommits/loltext/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Loltext
-    VERSION = "0.0.5".freeze
+    VERSION = "0.0.6".freeze
   end
 end

--- a/lib/lolcommits/plugin/loltext.rb
+++ b/lib/lolcommits/plugin/loltext.rb
@@ -8,15 +8,6 @@ module Lolcommits
         File.dirname(__FILE__), "../../../vendor/fonts/Impact.ttf"
       ).freeze
 
-      ##
-      # Returns the name of the plugin. Identifies the plugin to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'loltext'
-      end
-
       # Returns position(s) of when this plugin should run during the capture
       # process. We want to add text to the image after capturing, but before
       # capture is ready for sharing.
@@ -34,7 +25,7 @@ module Lolcommits
       # @return [Boolean] true/false indicating if plugin is enabled
       #
       def enabled?
-        !configured? || super
+        configuration.empty? || super
       end
 
       ##
@@ -46,7 +37,7 @@ module Lolcommits
       # @return [Boolean] true/false indicating if plugin is correct configured
       #
       def valid_configuration?
-        !configured? || super
+        configuration.empty? || super
       end
 
       ##
@@ -55,27 +46,20 @@ module Lolcommits
       # @return [Hash] a hash of configured plugin options
       #
       def configure_options!
-        options = super
-        if options['enabled']
-          puts '---------------------------------------------------------------'
-          puts '  LolText options '
-          puts ''
-          puts '  * any blank options will use the (default)'
-          puts '  * always use the full absolute path to fonts'
-          puts '  * valid text positions are NE, NW, SE, SW, S, C (centered)'
-          puts '  * colors can be hex #FC0 value or a string \'white\''
-          puts '      - use `none` for no stroke color'
-          puts '  * overlay fills your image with a random color'
-          puts '      - set one or more overlay_colors with a comma seperator'
-          puts '      - overlay_percent (0-100) sets the fill colorize strength'
-          puts '---------------------------------------------------------------'
+        puts '---------------------------------------------------------------'
+        puts '  LolText options '
+        puts ''
+        puts '  * any blank options will use the (default)'
+        puts '  * always use the full absolute path to fonts'
+        puts '  * valid text positions are NE, NW, SE, SW, S, C (centered)'
+        puts '  * colors can be hex #FC0 value or a string \'white\''
+        puts '      - use `none` for no stroke color'
+        puts '  * overlay fills your image with a random color'
+        puts '      - set one or more overlay_colors with a comma seperator'
+        puts '      - overlay_percent (0-100) sets the fill colorize strength'
+        puts '---------------------------------------------------------------'
 
-          options[:message] = configure_sub_options(:message)
-          options[:sha]     = configure_sub_options(:sha)
-          options[:overlay] = configure_sub_options(:overlay)
-          options[:border]  = configure_sub_options(:border)
-        end
-        options
+        super
       end
 
       ##
@@ -89,7 +73,7 @@ module Lolcommits
         image = MiniMagick::Image.open(runner.main_image)
         if config_option(:overlay, :enabled)
           image.combine_options do |c|
-            c.fill config_option(:overlay, :overlay_colors).sample
+            c.fill config_option(:overlay, :overlay_colors).split(',').map(&:strip).sample
             c.colorize config_option(:overlay, :overlay_percent)
           end
         end
@@ -143,31 +127,8 @@ module Lolcommits
         end
       end
 
-      # TODO: consider this type of configuration prompting in Plugin::Base
-      # i.e. allow sub option and working with hash of defaults
-      def configure_sub_options(type)
-        print "#{type}:\n"
-        defaults = config_defaults[type]
-
-        # sort option keys since different `Hash#keys` varys across Ruby versions
-        defaults.keys.sort_by(&:to_s).reduce({}) do |acc, opt|
-          # if we have an enabled key set to false, abort asking for any more options
-          if acc.key?(:enabled) && acc[:enabled] != true
-            acc
-          else
-            print "  #{opt.to_s.tr('_', ' ')} (#{defaults[opt]}): "
-            val = parse_user_input(gets.chomp.strip)
-            # handle array options (comma seperated string)
-            if defaults[opt].is_a?(Array) && !val.nil?
-              val = val.split(',').map(&:strip).delete_if(&:empty?)
-            end
-            acc.merge(opt => val)
-          end
-        end
-      end
-
       # default text styling and positions
-      def config_defaults
+      def default_options
         {
           message: {
             color: 'white',
@@ -191,25 +152,15 @@ module Lolcommits
               '#2e4970', '#674685', '#ca242f', '#1e7882', '#2884ae', '#4ba000',
               '#187296', '#7e231f', '#017d9f', '#e52d7b', '#0f5eaa', '#e40087',
               '#5566ac', '#ed8833', '#f8991c', '#408c93', '#ba9109'
-            ],
+            ].join(','),
             overlay_percent: 50
           },
           border: {
-            color: 'white',
             enabled: false,
+            color: 'white',
             size: 10,
           }
         }
-      end
-
-      # return the config option, defaults apply if not set
-      def config_option(type, option)
-        default_option = config_defaults[type][option]
-        if configuration[type]
-          configuration[type][option] || default_option
-        else
-          default_option
-        end
       end
 
       # explode psuedo-names for text positioning

--- a/lolcommits-loltext.gemspec
+++ b/lolcommits-loltext.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0.0"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.5"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"

--- a/test/lolcommits/plugin/loltext_test.rb
+++ b/test/lolcommits/plugin/loltext_test.rb
@@ -8,10 +8,6 @@ describe Lolcommits::Plugin::Loltext do
     'loltext'
   end
 
-  it 'should have a name' do
-    ::Lolcommits::Plugin::Loltext.name.must_equal plugin_name
-  end
-
   it 'should run on post capturing' do
     ::Lolcommits::Plugin::Loltext.runner_order.must_equal [:post_capture]
   end
@@ -27,9 +23,7 @@ describe Lolcommits::Plugin::Loltext do
   describe 'with a runner' do
     def runner
       # a simple lolcommits runner with an empty configuration Hash
-      @runner ||= Lolcommits::Runner.new(
-        config: OpenStruct.new(read_configuration: {})
-      )
+      @runner ||= Lolcommits::Runner.new
     end
 
     def plugin
@@ -37,17 +31,13 @@ describe Lolcommits::Plugin::Loltext do
     end
 
     def valid_enabled_config
-      @config ||= OpenStruct.new(
-        read_configuration: {
-          'loltext'=> { 'enabled' => true }
-        }
-      )
+      { enabled: true }
     end
 
     describe 'initalizing' do
       it 'should assign runner and an enabled option' do
         plugin.runner.must_equal runner
-        plugin.options.must_equal ['enabled']
+        plugin.options.must_equal [:enabled]
       end
     end
 
@@ -57,16 +47,12 @@ describe Lolcommits::Plugin::Loltext do
       end
 
       it 'should true when configured' do
-        plugin.config = valid_enabled_config
+        plugin.configuration = valid_enabled_config
         plugin.enabled?.must_equal true
       end
     end
 
     describe 'configuration' do
-      it 'should not be configured by default' do
-        plugin.configured?.must_equal false
-      end
-
       it 'should allow plugin options to be configured' do
         # enabled
         inputs = ['true']
@@ -82,10 +68,10 @@ describe Lolcommits::Plugin::Loltext do
         ) * 2
 
         # styling overlay
-        inputs += %w(true  #2884ae,#7e231f 40)
+        inputs += %w(true #2884ae,#7e231f 40)
 
         # border options
-        inputs += %w(#e96d46 true 23)
+        inputs += %w(true #e96d46 23)
 
         configured_plugin_options = {}
         fake_io_capture(inputs: inputs) do
@@ -93,7 +79,7 @@ describe Lolcommits::Plugin::Loltext do
         end
 
         configured_plugin_options.must_equal( {
-          "enabled" => true,
+          enabled: true,
           message: {
             color: 'red',
             font: 'myfont.ttf',
@@ -112,20 +98,15 @@ describe Lolcommits::Plugin::Loltext do
           },
           overlay: {
             enabled: true,
-            overlay_colors: ['#2884ae', '#7e231f'],
+            overlay_colors: "#2884ae,#7e231f",
             overlay_percent: 40
           },
           border: {
-            color: '#e96d46',
             enabled: true,
+            color: '#e96d46',
             size: 23,
           }
         })
-      end
-
-      it 'should indicate when configured' do
-        plugin.config = valid_enabled_config
-        plugin.configured?.must_equal true
       end
 
       describe '#valid_configuration?' do
@@ -134,7 +115,7 @@ describe Lolcommits::Plugin::Loltext do
         end
 
         it 'should be true for a valid configuration' do
-          plugin.config = valid_enabled_config
+          plugin.configuration = valid_enabled_config
           plugin.valid_configuration?.must_equal true
         end
       end


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method, plugins are now identified by their gem name
* drop calls to `configured?` (no longer available)
* change `configure_options!` to make call super making use of the new `default_options` hash
* bump gem version

NOTE: This PR changes the format of the overlay colours in the YAML config file (from an array to a comma separated string).