### PR TITLE
Rescure mogrify non zero exit errors

### DIFF
--- a/lib/lolcommits/plugin/loltext.rb
+++ b/lib/lolcommits/plugin/loltext.rb
@@ -125,6 +125,8 @@ module Lolcommits
           c.font config_option(type, :font)
           c.annotate annotate_location, string
         end
+      rescue => error
+        debug("mogrify annotate returned non-zero status: #{error.message}")
       end
 
       # default text styling and positions


### PR DESCRIPTION
This [issue](https://github.com/mroth/lolcommits/issues/371) reported in the lolcommits repo is due to later versions of Mogrify for ImageMagick (>=7) not working with the `stroke` option when annotating images with text.

On inspecting the image, however, the text appears to be rendered correctly and we error out in the gem due to the non-zero exit code (1) returned from Mogrify.

This PR rescues and logs errors (to debug) when this happens, rather than raising and exiting the capture process.
