### PR TITLE
Composite overlay on top of actual videos

### DIFF
--- a/lib/lolcommits/plugin/loltext.rb
+++ b/lib/lolcommits/plugin/loltext.rb
@@ -70,32 +70,77 @@ module Lolcommits
       #
       def run_post_capture
         debug 'Annotating image via MiniMagick'
-        image = MiniMagick::Image.open(runner.main_image)
+        # image = MiniMagick::Image.open(runner.main_image)
+        if runner.capture_animated?
+          image = MiniMagick::Image.open(runner.video_loc)
+        else
+          image = MiniMagick::Image.open(runner.snapshot_loc)
+        end
+
+        overlay_image = make_overlay_image(image)
+        debug "Compositing overlay"
+        debug "#{overlay_image.path}"
+
+        if runner.capture_animated? && File.exists?(runner.main_video) != ""
+          `ffmpeg -v quiet -nostats -i #{runner.video_loc} -i #{overlay_image.path} \
+          -filter_complex \
+          "scale2ref[0:v][1:v];[0:v][1:v] overlay=0:0" \
+          -y #{runner.main_video}`
+        else
+          result = image.composite(overlay_image) do |c|
+            c.compose "src-over"
+            c.gravity "center"
+          end
+          debug "Writing changed file to #{runner.main_image}"
+          result.write runner.main_image
+        end
+      end
+
+      def make_overlay_image(image)
+        debug "Making overlay image"
+        new_tempfile = MiniMagick::Utilities.tempfile(".png")
+
+        overlay_image = MiniMagick::Tool::Convert.new do |i|
+          i.size "#{image.width}x#{image.height}"
+          i.xc "transparent"
+          i << new_tempfile.path
+        end
+
+        overlay_image = MiniMagick::Image.open(new_tempfile.path)
+
         if config_option(:overlay, :enabled)
-          image.combine_options do |c|
-            c.fill config_option(:overlay, :overlay_colors).split(',').map(&:strip).sample
-            c.colorize config_option(:overlay, :overlay_percent)
+          debug "Making colored overlay"
+          color = config_option(:overlay, :overlay_colors).sample
+          overlay_percent = config_option(:overlay, :overlay_percent).to_f
+          overlay_percent = (255 * (overlay_percent/100)).round
+
+          overlay_image.combine_options do |c|
+            c.fill "#{color}#{sprintf('%02X',overlay_percent)}"
+            c.draw "color 0,0 reset"
           end
         end
 
         if config_option(:border, :enabled)
-          image.combine_options do |c|
-            c.border "#{config_option(:border, :size)}x#{config_option(:border, :size)}"
+          debug "Adding border to overlay"
+          # mogrify doesn't allow compose, format forces use of convert
+          overlay_image.format("PNG32") do |c|
+            c.compose "Copy"
             c.bordercolor config_option(:border, :color)
+            c.border config_option(:border, :size)
           end
         end
 
-        annotate(image, :message, clean_msg(runner.message))
-        annotate(image, :sha, runner.sha)
-        debug "Writing changed file to #{runner.main_image}"
-        image.write runner.main_image
+        annotate(overlay_image, :message, clean_msg(runner.message))
+        annotate(overlay_image, :sha, runner.sha)
+
+        overlay_image
       end
 
 
       private
 
       def annotate(image, type, string)
-        debug("annotating #{type} to image with #{string}")
+        debug("annotating #{type} to overlay image with #{string}")
 
         transformed_position = position_transform(config_option(type, :position))
         annotate_location = '0'
@@ -116,12 +161,12 @@ module Lolcommits
         string.upcase! if config_option(type, :uppercase)
 
         image.combine_options do |c|
-          c.strokewidth runner.capture_animated? ? '1' : '2'
+          c.strokewidth 2
           c.interline_spacing(-(config_option(type, :size) / 5))
           c.stroke config_option(type, :stroke_color)
           c.fill config_option(type, :color)
           c.gravity transformed_position
-          c.pointsize runner.capture_animated? ? (config_option(type, :size) / 2) : config_option(type, :size)
+          c.pointsize config_option(type, :size)
           c.font config_option(type, :font)
           c.annotate annotate_location, string
         end

--- a/lib/lolcommits/plugin/loltext.rb
+++ b/lib/lolcommits/plugin/loltext.rb
@@ -88,7 +88,6 @@ module Lolcommits
           -y #{runner.main_video}`
         else
           result = image.composite(overlay_image) do |c|
-            c.compose "src-over"
             c.gravity "center"
           end
           debug "Writing changed file to #{runner.main_image}"
@@ -97,9 +96,8 @@ module Lolcommits
       end
 
       def make_overlay_image(image)
-        debug "Making overlay image"
+        debug "Making overlay image #{image.width}x#{image.height}"
         new_tempfile = MiniMagick::Utilities.tempfile(".png")
-
         overlay_image = MiniMagick::Tool::Convert.new do |i|
           i.size "#{image.width}x#{image.height}"
           i.xc "transparent"
@@ -121,10 +119,11 @@ module Lolcommits
         end
 
         if config_option(:border, :enabled)
-          debug "Adding border to overlay"
+          debug "Adding border to overlay with #{config_option(:border, :color)} at size #{config_option(:border, :size)}"
           # mogrify doesn't allow compose, format forces use of convert
           overlay_image.format("PNG32") do |c|
             c.compose "Copy"
+            c.shave config_option(:border, :size)
             c.bordercolor config_option(:border, :color)
             c.border config_option(:border, :size)
           end

--- a/lib/lolcommits/plugin/loltext.rb
+++ b/lib/lolcommits/plugin/loltext.rb
@@ -110,7 +110,7 @@ module Lolcommits
 
         if config_option(:overlay, :enabled)
           debug "Making colored overlay"
-          color = config_option(:overlay, :overlay_colors).sample
+          color = config_option(:overlay, :overlay_colors).split(',').map(&:strip).sample
           overlay_percent = config_option(:overlay, :overlay_percent).to_f
           overlay_percent = (255 * (overlay_percent/100)).round
 


### PR DESCRIPTION
Requires https://github.com/mroth/lolcommits/pull/386

Allows compositing overlays on top of ACTUAL videos.