### PR TITLE
Use runner overlay image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog][KeepAChangelog] and this project
-adheres to [Semantic Versioning][Semver].
+The format is based on [Keep a Changelog][KeepAChangelog] and this
+project adheres to [Semantic Versioning][Semver].
 
 ## [Unreleased]
 
 - Your contribution here!
+
+## [0.2.0] - 2019-05-10
+### Changed
+- use runner.overlay instance to build overlay (requires at least
+lolcommits 0.14.0)
+- improved debug messages throughout
+
+### Removed
+- Support for lolcommits < 0.14.0
 
 ## [0.1.0] - 2019-04-24
 ### Removed
@@ -63,7 +72,8 @@ adheres to [Semantic Versioning][Semver].
 ### Changed
 - Initial release (Yanked)
 
-[Unreleased]: https://github.com/lolcommits/lolcommits-loltext/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/lolcommits/lolcommits-loltext/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/lolcommits/lolcommits-loltext/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/lolcommits/lolcommits-loltext/compare/v0.9.0...v0.1.0
 [0.0.9]: https://github.com/lolcommits/lolcommits-loltext/compare/v0.0.8...v0.0.9
 [0.0.8]: https://github.com/lolcommits/lolcommits-loltext/compare/v0.0.7...v0.0.8

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Explain what you're changing and why here.
 
 Please check this list and leave it intact for the reviewer. Thanks! :heart:
 
-- [ ] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
+- [ ] Commit messages to provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
 - [ ] If relevant, mention GitHub issue number above and include in a commit message.
 - [ ] Latest code from master merged.
 - [ ] New behaviour has test coverage.

--- a/lib/lolcommits/loltext/version.rb
+++ b/lib/lolcommits/loltext/version.rb
@@ -2,6 +2,6 @@
 
 module Lolcommits
   module Loltext
-    VERSION = "0.1.0".freeze
+    VERSION = "0.2.0".freeze
   end
 end

--- a/lolcommits-loltext.gemspec
+++ b/lolcommits-loltext.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_development_dependency "lolcommits", ">= 0.11.0"
+  spec.add_development_dependency "lolcommits", ">= 0.14.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
Based on @Ruxton's PR #5  - we'll now make use of a new `runner.overlay` (an instance of `MiniMagick::Image`) - to annotate, colorize and borderize. Rather than write the file with this gem, the lolcommits gem will take care of applying this to the image (or video/animated gif).

---

In the latest version of lolcommits (`v0.14.0` yet to be released), this `overlay` object will be available through the `runner`. Allowing any plugin to manipulate an initially empty PNG file (width/height matching the capture) that will be overlayed onto the lolcommit (after `post_capture`, and before `capture_ready` hooks run).

---

This PR also bumps the gem version to `0.2.0` in preparation for a new release.

---
#### :memo: Checklist

Please check this list and leave it intact for the reviewer. Thanks! :heart:

- [x] Commit messages to provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [x] If relevant, mention GitHub issue number above and include in a commit message.
- [x] Latest code from master merged.
- [ ] New behaviour has test coverage.
- [x] Avoid duplicating code.
- [x] No commented out code.
- [x] Avoid comments for your code, write code that explains itself.
- [x] Changes are simple, useful, clear and brief.